### PR TITLE
fix: sample UploadController for CKEditor adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ dotnet build ckeditor5blazor.sln
 dotnet run --project ckeditor5blazor
 ```
 
+### Sample image upload API
+
+This repo now includes `Controllers/UploadController.cs` — a minimal endpoint the custom adapter can call:
+
+- **Method / route:** `POST /api/Upload`
+- **Form field:** `upload` (multipart)
+- **Response JSON:** `{ "url": "https://host/uploads/filename.ext" }`
+
+The demo page points `UrlToPostImage` at `/api/Upload`. Files are saved under `wwwroot/uploads/`.
+
+```csharp
+[HttpPost]
+public async Task<IActionResult> Post(IFormFile upload)
+{
+    // save file under wwwroot/uploads, then:
+    return Ok(new { url = $"{Request.Scheme}://{Request.Host}/uploads/{storedName}" });
+}
+```
+
 ### Basic usage
 
 ```razor
@@ -37,7 +56,7 @@ dotnet run --project ckeditor5blazor
 <EditForm Model="@editorOptions">
     <CKEditorBlazor Id="MyEditor1"
                     @bind-Value=@editorOptions.InitialText
-                    UrlToPostImage="https://localhost:44301/api/upload">
+                    UrlToPostImage="/api/Upload">
     </CKEditorBlazor>
 </EditForm>
 ```
@@ -50,9 +69,9 @@ CKEditor image upload is handled by an **upload adapter**. This sample uses a **
 
 ## Known gaps / help wanted
 
-- WebAssembly packaging polish
-- Strikethrough / additional plugin examples
-- Avoid base64-only uploads when a URL endpoint is configured
+- **WebAssembly:** sample is Blazor Server today; a dedicated WASM host is not in the solution yet
+- **Strikethrough:** not included in the bundled `ckeditor.js` ClassicEditor build — needs a custom CKEditor rebuild + toolbar item
+- Paste/`imageInsert` can still embed base64 images even when `UrlToPostImage` is set
 
 See [open issues](https://github.com/qmmughal/ckeditor5-blazor/issues).
 

--- a/ckeditor5blazor/Controllers/UploadController.cs
+++ b/ckeditor5blazor/Controllers/UploadController.cs
@@ -1,0 +1,49 @@
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ckeditor5blazor.Controllers
+{
+    /// <summary>
+    /// Sample upload endpoint for the CKEditor custom adapter in wwwroot/js/CKEditorInterop.js.
+    /// The adapter POSTs multipart form field "upload" and expects JSON: { "url": "..." }.
+    /// </summary>
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UploadController : ControllerBase
+    {
+        private readonly IWebHostEnvironment _env;
+
+        public UploadController(IWebHostEnvironment env)
+        {
+            _env = env;
+        }
+
+        [HttpPost]
+        [RequestSizeLimit(10_000_000)]
+        public async Task<IActionResult> Post(IFormFile upload)
+        {
+            if (upload == null || upload.Length == 0)
+            {
+                return BadRequest(new { error = new { message = "No file in form field 'upload'." } });
+            }
+
+            var uploadsDir = Path.Combine(_env.WebRootPath ?? "wwwroot", "uploads");
+            Directory.CreateDirectory(uploadsDir);
+
+            var safeName = Path.GetFileName(upload.FileName);
+            var storedName = $"{Path.GetFileNameWithoutExtension(safeName)}_{Path.GetRandomFileName()}{Path.GetExtension(safeName)}";
+            var path = Path.Combine(uploadsDir, storedName);
+
+            await using (var stream = System.IO.File.Create(path))
+            {
+                await upload.CopyToAsync(stream);
+            }
+
+            var url = $"{Request.Scheme}://{Request.Host}/uploads/{storedName}";
+            return Ok(new { url });
+        }
+    }
+}

--- a/ckeditor5blazor/Pages/Index.razor
+++ b/ckeditor5blazor/Pages/Index.razor
@@ -6,7 +6,7 @@
 <EditForm Model="@editorOptions">
     <CKEditorBlazor Id="MyEditor1" 
                     @bind-Value=@editorOptions.InitialText 
-                    UrlToPostImage="http://localhost:44301/api/qaiser/Upload">
+                    UrlToPostImage="/api/Upload">
     </CKEditorBlazor>
 </EditForm>
 

--- a/ckeditor5blazor/Startup.cs
+++ b/ckeditor5blazor/Startup.cs
@@ -26,6 +26,7 @@ namespace ckeditor5blazor
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddControllers();
             services.AddRazorPages();
             services.AddServerSideBlazor();
         }
@@ -51,6 +52,7 @@ namespace ckeditor5blazor
 
             app.UseEndpoints(endpoints =>
             {
+                endpoints.MapControllers();
                 endpoints.MapBlazorHub();
                 endpoints.MapFallbackToPage("/_Host");
             });


### PR DESCRIPTION
﻿## Summary
- Add POST /api/Upload sample matching the custom adapter contract (form field upload, JSON url)
- Point demo UrlToPostImage at /api/Upload
- Document sample and known gaps (WASM / strikethrough / base64) in README

## Test plan
- [ ] dotnet run --project ckeditor5blazor
- [ ] Upload an image in the editor; file appears under wwwroot/uploads
